### PR TITLE
fix typo in bloom.md

### DIFF
--- a/docs/05 Advanced Lighting/07 Bloom.md
+++ b/docs/05 Advanced Lighting/07 Bloom.md
@@ -179,7 +179,7 @@ void main()
 GLuint pingpongFBO[2];
 GLuint pingpongBuffer[2];
 glGenFramebuffers(2, pingpongFBO);
-glGenTextures(2, pingpongColorbuffers);
+glGenTextures(2, pingpongBuffer);
 for (GLuint i = 0; i < 2; i++)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, pingpongFBO[i]);


### PR DESCRIPTION
对照原文，此段代码变量名应为pingpongBuffer
https://learnopengl.com/Advanced-Lighting/Bloom