### PR TITLE
fix: `Shaders` 这节中 `int main` 的笔误

### DIFF
--- a/docs/01 Getting started/05 Shaders.md
+++ b/docs/01 Getting started/05 Shaders.md
@@ -27,7 +27,7 @@ out type out_variable_name;
 
 uniform type uniform_name;
 
-int main()
+void main()
 {
   // 处理输入并进行一些图形操作
   ...


### PR DESCRIPTION
我参照了[原教程页面](https://learnopengl.com/Getting-started/Shaders)，发现中文文档的这里将 `void main` 写为了 `int main`，与 GLSL 语法产生出入，故作出修正